### PR TITLE
Update install.sh

### DIFF
--- a/dist/install.sh
+++ b/dist/install.sh
@@ -26,6 +26,6 @@ if [ ! -f "/etc/tls-shunt-proxy/config.yaml" ]; then
 fi
 
 mkdir -p '/etc/ssl/tls-shunt-proxy'
-chown tls-shunt-proxy:tls-shunt-proxy /etc/ssl/tls-shunt-proxy
+chown -R tls-shunt-proxy:tls-shunt-proxy /etc/ssl/tls-shunt-proxy
 
 rm -r "${VSRC_ROOT}"


### PR DESCRIPTION
修复在"卸载tls-shunt-proxy"并删除tls-shunt-proxy用户，但没有清理/etc/ssl/tls-shunt-proxy/目录的情况下，使用脚本重新安装后，证书目录无权限的问题。